### PR TITLE
Bump the peerDependencies.express property.

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,6 @@
     "supertest": "^0.9.2"
   },
   "peerDependencies": {
-    "express": ">=4.13.3"
+    "express": ">=4.14.0"
   }
 }


### PR DESCRIPTION
Kept getting error:
Command failed: npm ERR! missing: express@>=4.13.3, required by fh-rest-express-router@0.3.1

Bumping the peerDependencies express property value to match the devDependencies express value at 4.14.0 fixed the issue.

Tests pass and the MBaaS using this version of the package.json tested clean and is functioning as expected.