### PR TITLE
Pass req.query through for reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ const ordersRouter = fhRestExpressRouter({
   name: 'orders',
 
   // Joi schemas that validate the querystring/body is safe to pass to
-  // an adapter instance. Only for list, create, and update
+  // an adapter instance. Only for list, create, update and read
   bodyAndQueryValidations: {
     'list': [{
       schema: require('./validate-list-schema.js'),
@@ -131,7 +131,13 @@ const ordersRouter = fhRestExpressRouter({
       options: {
         noDefaults: true // Do not use default values set in Joi schema
       }
-    })]
+    })],
+    'read': [{
+      schema: require('./validate-read-schema.js',
+      options: {
+        abortEarly: false // Run all validations and return any and all errors
+      }
+    }]
   },
 
   // Similar to the bodyAndQueryValidations, but operates on route params,
@@ -306,6 +312,7 @@ Sample response:
 
 ```json
 {
+  "group": "admin",
   "firstname": "red",
   "lastname": "hatter"
 }
@@ -334,9 +341,9 @@ Sample response:
 ## Changelog
 
 * 0.9.0
-  * Update router events so that the signature has changed from fn(newData) to 
+  * Update router events so that the signature has changed from fn(newData) to
   fn(newData, extraData). In an adapter function simply pass a third param to
-  the callback and it will be the _extraData_ in the related router.event. 
+  the callback and it will be the _extraData_ in the related router.event.
 
 * 0.8.0
   * Expand on previous Joi additions by utilising these for validation of URL

--- a/README.md
+++ b/README.md
@@ -127,13 +127,13 @@ const ordersRouter = fhRestExpressRouter({
       }
     }],
     'update': [{
-      schema: require('./validate-update-schema.js',
+      schema: require('./validate-update-schema.js'),
       options: {
         noDefaults: true // Do not use default values set in Joi schema
       }
     })],
     'read': [{
-      schema: require('./validate-read-schema.js',
+      schema: require('./validate-read-schema.js'),
       options: {
         abortEarly: false // Run all validations and return any and all errors
       }
@@ -339,6 +339,9 @@ Sample response:
 * @matzew
 
 ## Changelog
+
+* 10.0.0
+  * Querystrings with Joi validation support are available for read operations.
 
 * 0.9.0
   * Update router events so that the signature has changed from fn(newData) to

--- a/lib/router.js
+++ b/lib/router.js
@@ -134,6 +134,7 @@ module.exports = function fhRestExpressRouter (opts) {
       'read',
       {
         routeParams: req.params,
+        query: req.query,
         id: req.params.id
       },
       onAdapterExecComplete('read', res, next)

--- a/lib/router.test.js
+++ b/lib/router.test.js
@@ -202,13 +202,16 @@ describe(__filename, function () {
       adapter.read.yields(null, readRes);
 
       request
-        .get('/1234')
+        .get('/1234?group=admin')
         .expect(200)
         .expect('content-type', /json/)
         .end(function (err, res) {
           expect(res.body).to.deep.equal(readRes);
           expect(adapter.read.getCall(0).args[0]).to.deep.equal({
             id: '1234',
+            query: {
+              group: 'admin'
+            },
             routeParams: {
               id: '1234'
             }

--- a/lib/validate-request/index.test.js
+++ b/lib/validate-request/index.test.js
@@ -268,7 +268,7 @@ describe(__filename, function () {
         .expect('content-type', /json/)
         .end(function (err, res) {
           expect(err).to.not.exist;
-          expect(res.body).to.eql({who: 'Sue'})
+          expect(res.body).to.eql({who: 'Sue'});
 
           done();
         });

--- a/lib/validate-request/validate-body-or-query.js
+++ b/lib/validate-request/validate-body-or-query.js
@@ -25,7 +25,7 @@ module.exports = function (opts) {
    */
   return function _routeParamsMiddleware (req, res, next) {
     const requestType = getRequestType(req);
-    const data = requestType === 'list' ? req.query : req.body;
+    const data = requestType === 'list' || requestType === 'read' ? req.query : req.body;
 
     log.debug(
       'validating route params for request %s %s, with type "%s"',
@@ -39,11 +39,11 @@ module.exports = function (opts) {
         next(err);
       } else {
         var removedParams = _.difference(_.keys(data), _.keys(validParams));
-        
+
         if (removedParams.length > 0) {
           log.info(
             '%s params removed for "%s" during joi validation: %j. %s %s',
-            requestType === 'list' ? 'req.query' : 'req.body',
+            requestType === 'list' || requestType === 'read' ? 'req.query' : 'req.body',
             requestType,
             removedParams,
             req.method,
@@ -51,8 +51,8 @@ module.exports = function (opts) {
           );
         }
 
-        // List operates on req.query, update and create operate on req.body
-        if (requestType === 'list') {
+        // List ond read operate on req.query, update and create operate on req.body
+        if (requestType === 'list' || requestType === 'read') {
           req.query = validParams;
         } else {
           req.body = validParams;

--- a/lib/validate-request/validate-validate-options.js
+++ b/lib/validate-request/validate-validate-options.js
@@ -8,7 +8,7 @@ const _ = require('lodash');
 /**
  * Validate that a validation option meets our required structure. Valid keys
  * are "create", "read", "update", "delete", and "list". Each of these keys
- * must be an Array of Objects that contains a "schema" and an ptional
+ * must be an Array of Objects that contains a "schema" and an optional
  * "options" object to alter the behavior of the validator
  *
  * {


### PR DESCRIPTION
Good for mongo projections or other logic that could kicked off based on a query parameter value.